### PR TITLE
get application mode and add it to track function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tracking-wallet",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tracking-wallet",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "dependencies": {
     "jquery": "^3.3.1"
   },

--- a/src/js/tracking-wallet.js
+++ b/src/js/tracking-wallet.js
@@ -575,7 +575,9 @@
   var track = function (event, attrs) {
     if (isTrackingEnabled()) {
       var objectToSend = window.$.extend({}, defaultData, attrs);
-
+      if(config.traits.applicationMode){
+        objectToSend.applicationMode = config.traits.applicationMode;
+      }
       if (event === Constants.pageViewEvent) {
         trackPageViewEvent(objectToSend);
       } else {
@@ -651,9 +653,13 @@
       var userId = null;
       var traits = null;
 
-      if (typeof initialOptions !== 'undefined' && typeof initialOptions.userId !== 'undefined') {
-        userId = initialOptions.userId;
-        traits = initialOptions.traits;
+      if (typeof initialOptions !== 'undefined'){
+        if( typeof initialOptions.userId !== 'undefined') {
+          userId = initialOptions.userId;
+        }
+        if( typeof initialOptions.traits !== 'undefined') {
+          traits = initialOptions.traits;
+        }
       }
 
       window.analytics.identify(userId, traits, {}, _postInitProcess);

--- a/src/js/tracking-wallet.js
+++ b/src/js/tracking-wallet.js
@@ -575,9 +575,11 @@
   var track = function (event, attrs) {
     if (isTrackingEnabled()) {
       var objectToSend = window.$.extend({}, defaultData, attrs);
-      if(config.traits.applicationMode){
+
+      if(config.traits && config.traits.applicationMode){
         objectToSend.applicationMode = config.traits.applicationMode;
       }
+
       if (event === Constants.pageViewEvent) {
         trackPageViewEvent(objectToSend);
       } else {


### PR DESCRIPTION
We have found that trying to set up superProperties without any previous userId will not set the property fo the events we track when we init the library -> https://segment.com/docs/connections/destinations/catalog/mixpanel/#set-people-properties

As we need to keep track of the application mode we need to be able to access this data before we have the user email, we have set a property, so anybody consuming the library can track the applicationMode in the init call